### PR TITLE
Replace exec-sync dep with node 0.12 child_process execSync

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 var through = require('through')
-var GIT_VERSION = require('exec-sync')('git rev-parse HEAD')
+var GIT_VERSION = require('child_process').execSync('git rev-parse HEAD')
 
 
 var firstTime = true

--- a/package.json
+++ b/package.json
@@ -20,10 +20,12 @@
     "type": "git",
     "url": "https://github.com/kumavis/browserify-commit-sha"
   },
+  "engines": {
+    "node": "0.12.x"
+  },
   "license": "MIT",
   "devDependencies": {},
   "dependencies": {
-    "through": "^2.3.4",
-    "exec-sync": "~0.1.6"
+    "through": "^2.3.4"
   }
 }


### PR DESCRIPTION
The 'exec-sync' module has native dependencies, couldn't get it to easily build on my system (OS X), and https://www.npmjs.com/package/exec-sync 's repository https://github.com/jeremyfa/node-exec-sync says "IMPORTANT: This repository is no longer maintained. For the same feature, use this instead: https://github.com/mgutz/execSync " - but that module is also unmaintained, though it points out an alternative:
- both iojs and node.js v0.12 have execSync function (http://strongloop.com/strongblog/whats-new-in-node-js-v0-12-execsync-a-synchronous-api-for-child-processes/)

Replaced exec-sync in browserify-commit-sha with child_process execSync on node v0.12, works great in my testing. (This does remove browserify-commit-sha compatibility with older node versions like v0.10, if older compatibility is desired this (GPL) module looks like a decent choice: https://www.npmjs.com/package/sync-exec - didn't try it myself though)
