### PR TITLE
Change to save version and date to global variables, instead of comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@ The output looks like this:
 (function (process){
 
 
-/**
-*
-* latest commit: c6541cbdf842e204fd2a958a28e83ba7be42f3c9
-* created at: Sun Feb 15 2015 17:18:10 GMT-0500 (PET)
-*
-**/
+
+
+window.GIT_VERSION = "c6541cbdf842e204fd2a958a28e83ba7be42f3c9";
+window.CREATED_AT = "Sun Feb 15 2015 17:18:10 GMT-0500 (PET)";
+
+
 
 'use strict';
 
@@ -27,5 +27,3 @@ var y = require('y')
 
 
 Its a bit of a hack, but it works alright.
-You'll most likely want to do this another way,
-such that it survives minification

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ The output looks like this:
 
 
 
-window.GIT_VERSION = "c6541cbdf842e204fd2a958a28e83ba7be42f3c9";
-window.CREATED_AT = "Sun Feb 15 2015 17:18:10 GMT-0500 (PET)";
+window.__BROWSERIFY_META_DATA__GIT_VERSION = "c6541cbdf842e204fd2a958a28e83ba7be42f3c9";
+window.__BROWSERIFY_META_DATA__CREATED_AT = "Sun Feb 15 2015 17:18:10 GMT-0500 (PET)";
 
 
 

--- a/index.js
+++ b/index.js
@@ -14,8 +14,8 @@ module.exports = function (bundle) {
       var notification = '\n'+[
         '',
         '',
-        'window.GIT_VERSION = "' + GIT_VERSION + '";',
-        'window.CREATED_AT = "' + new Date() + '";',
+        'global.__BROWSERIFY_META_DATA__GIT_VERSION = "' + GIT_VERSION + '";',
+        'global.__BROWSERIFY_META_DATA__CREATED_AT = "' + new Date() + '";',
         '',
         '',
       ].join('\n')+'\n\n'

--- a/index.js
+++ b/index.js
@@ -12,12 +12,12 @@ module.exports = function (bundle) {
   function write(buf) {
     if (firstTime) {
       var notification = '\n'+[
-        '/**',
-        '* ',
-        '* latest commit: ' + GIT_VERSION,
-        '* created at: ' + new Date(),
-        '* ',
-        '**/',
+        '',
+        '',
+        'window.GIT_VERSION = "' + GIT_VERSION + '";',
+        'window.CREATED_AT = "' + new Date() + '";',
+        '',
+        '',
       ].join('\n')+'\n\n'
       stream.queue(notification)
       firstTime = false


### PR DESCRIPTION
imho, it is more convenient to have the git version and dates available in global variables, rather than comments. Users can then open the browser console to print the values of these variables, or other code can be written to look at these variables and display them wherever appropriate (about dialogs, diagnostic reports, etc.). The values of course can still be visible by viewing the source.

This PR uses `GIT_VERSION` and `CREATED_AT`, but I'm not attached to these names (better alternatives to avoid possible naming clashes? something on a _browserify_commit_sha object? maybe it should be an option? idk)

(As a side-effect, this change also allows browserify-commit-sha to easily work with coffeeify, or other transforms from languages that have the same variable assignment and string literal syntax, but a comment syntax differing from JavaScript. If, for some reason, they run after this transform)
