### PR TITLE
(broken) Change to use sync-exec module (vs exec-sync or node 0.12 child_process execSync)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 var through = require('through')
-var GIT_VERSION = require('child_process').execSync('git rev-parse HEAD')
+var exec = require('sync-exec')
 
+var GIT_VERSION = exec('git rev-parse HEAD').stdout.replace('\n', '')
 
 var firstTime = true
 

--- a/package.json
+++ b/package.json
@@ -13,19 +13,22 @@
     "version"
   ],
   "author": "kumavis",
-  "contributors": [{
-    "name": "blackbing"
-  }],
+  "contributors": [
+    {
+      "name": "blackbing",
+    },
+    {
+      "name": "deathcap",
+    }
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/kumavis/browserify-commit-sha"
   },
-  "engines": {
-    "node": "0.12.x"
-  },
   "license": "MIT",
   "devDependencies": {},
   "dependencies": {
+    "sync-exec": "^0.4.0",
     "through": "^2.3.4"
   }
 }


### PR DESCRIPTION
Not ready to pull, opening this to save what I have so far. In theory the https://www.npmjs.com/package/sync-exec should be better than node.js 0.12-only child_process execSync, since it is compatible with 0.10 and earlier, or https://www.npmjs.com/package/exec-sync since it is not unmaintained, but for some reason this change despite working in isolation fails when I try to use it:

```
$ beefy index.coffee:bundle.js --watchify --port 8080 -- --debug --transform browserify-commit-sha
beefy (v2.1.3) is listening on http://127.0.0.1:8080
/Users/admin/games/voxeljs/voxpopuli/node_modules/browserify/node_modules/resolve/lib/async.js:93
                if (pkg.main) {
                       ^
TypeError: Cannot read property 'main' of undefined
    at /Users/admin/games/voxeljs/voxpopuli/node_modules/browserify/node_modules/resolve/lib/async.js:93:24
    at fs.js:336:14
    at /Users/admin/games/voxeljs/voxpopuli/node_modules/watchify/node_modules/chokidar/node_modules/readdirp/node_modules/graceful-fs/graceful-fs.js:104:5
    at /Users/admin/.nvm/versions/node/v0.12.0/lib/node_modules/beefy/node_modules/chokidar/node_modules/readdirp/node_modules/graceful-fs/graceful-fs.js:104:5
    at FSReqWrap.oncomplete (fs.js:99:15)
```

same command works fine with browserify-commit-sha master (0.1.0 release with node execSync), not sure why this breaks it (have not investigated)
